### PR TITLE
Updating colours

### DIFF
--- a/app/tips/page.jsx
+++ b/app/tips/page.jsx
@@ -60,7 +60,7 @@ export default function TipsPage() {
       <div className="w-full max-w-3xl space-y-8">
         {/* Comet image placeholder */}
         <div className="h-40 flex items-center justify-center">
-          <div className="w-20 h-20 bg-green-400 rounded-full blur-2xl opacity-50"></div>
+          <div className="w-20 h-20 bg-[#2D1537] rounded-full blur-2xl opacity-50"></div>
         </div>
 
         <h1 className="text-5xl font-bold text-center text-[#2D1537] ">TypeScript Tips</h1>

--- a/app/tips/workshops/page.jsx
+++ b/app/tips/workshops/page.jsx
@@ -37,7 +37,7 @@ export default function Workshops() {
                 TypeScript Pro Essentials
               </h2>
               <div className="flex flex-wrap justify-center sm:justify-start gap-2">
-                <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                <span className="bg-[#2D1537] text-black text-xs font-bold px-2 py-1 rounded">
                   NEW
                 </span>
                 <span className="text-gray-400 text-xs sm:text-sm">
@@ -71,7 +71,7 @@ export default function Workshops() {
                 TypeScript Pro Essentials
               </h2>
               <div className="flex flex-wrap justify-center sm:justify-start gap-2">
-                <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                <span className="bg-[#2D1537] text-black text-xs font-bold px-2 py-1 rounded">
                   NEW
                 </span>
                 <span className="text-gray-400 text-xs sm:text-sm">
@@ -105,7 +105,7 @@ export default function Workshops() {
                 TypeScript Pro Essentials
               </h2>
               <div className="flex flex-wrap justify-center sm:justify-start gap-2">
-                <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                <span className="bg-[#2D1537] text-black text-xs font-bold px-2 py-1 rounded">
                   NEW
                 </span>
                 <span className="text-gray-400 text-xs sm:text-sm">
@@ -139,7 +139,7 @@ export default function Workshops() {
                 TypeScript Pro Essentials
               </h2>
               <div className="flex flex-wrap justify-center sm:justify-start gap-2">
-                <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                <span className="bg-[#2D1537] text-black text-xs font-bold px-2 py-1 rounded">
                   NEW
                 </span>
                 <span className="text-gray-400 text-xs sm:text-sm">
@@ -173,7 +173,7 @@ export default function Workshops() {
                 TypeScript Pro Essentials
               </h2>
               <div className="flex flex-wrap justify-center sm:justify-start gap-2">
-                <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                <span className="bg-[#2D1537] text-black text-xs font-bold px-2 py-1 rounded">
                   NEW
                 </span>
                 <span className="text-gray-400 text-xs sm:text-sm">


### PR DESCRIPTION
This pull request includes changes to the color scheme of the `TipsPage` and `Workshops` components. The most important changes involve updating the background color of certain elements to a new color code.

Color scheme updates:

* [`app/tips/page.jsx`](diffhunk://#diff-49baa3aacd6cbf57f27b9d83e028f1e587466693a9306a87be2ef31e89f2e809L63-R63): Changed the background color of the comet image placeholder from green to `#2D1537`.
* [`app/tips/workshops/page.jsx`](diffhunk://#diff-d2b0746531a944bb2fcb13bbc02e49d4fffc0ece8872d28bc395e96341ec6120L40-R40): Updated the background color of the "NEW" label from green to `#2D1537` in multiple instances. [[1]](diffhunk://#diff-d2b0746531a944bb2fcb13bbc02e49d4fffc0ece8872d28bc395e96341ec6120L40-R40) [[2]](diffhunk://#diff-d2b0746531a944bb2fcb13bbc02e49d4fffc0ece8872d28bc395e96341ec6120L74-R74) [[3]](diffhunk://#diff-d2b0746531a944bb2fcb13bbc02e49d4fffc0ece8872d28bc395e96341ec6120L108-R108) [[4]](diffhunk://#diff-d2b0746531a944bb2fcb13bbc02e49d4fffc0ece8872d28bc395e96341ec6120L142-R142) [[5]](diffhunk://#diff-d2b0746531a944bb2fcb13bbc02e49d4fffc0ece8872d28bc395e96341ec6120L176-R176)