### PR TITLE
CORE: standardize capitalization and update styling for Mentoring and…

### DIFF
--- a/app/docs/mentoring/choosing/page.jsx
+++ b/app/docs/mentoring/choosing/page.jsx
@@ -29,13 +29,13 @@ export default function Choosing() {
             </Link>
             <Link
               href="/docs/mentoring"
-              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Mentoring
             </Link>
             <Link
               href="/docs/community"
-              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Community
             </Link>
@@ -59,7 +59,7 @@ export default function Choosing() {
                 href="/docs/mentoring"
                 className="block px-4 py-2 text-gray-600 hover:text-gray-900"
               >
-                mentoring
+                Mentoring
               </Link>
               <Link
                 href="/docs/mentoring/choosing"

--- a/app/docs/mentoring/feedback/page.jsx
+++ b/app/docs/mentoring/feedback/page.jsx
@@ -29,13 +29,13 @@ export default function Feedback() {
             </Link>
             <Link
               href="/docs/mentoring"
-              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Mentoring
             </Link>
             <Link
               href="/docs/community"
-              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Community
             </Link>

--- a/app/docs/mentoring/markdown/page.jsx
+++ b/app/docs/mentoring/markdown/page.jsx
@@ -29,13 +29,13 @@ export default function Markdown() {
             </Link>
             <Link
               href="/docs/mentoring"
-              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Mentoring
             </Link>
             <Link
               href="/docs/community"
-              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Community
             </Link>
@@ -59,7 +59,7 @@ export default function Markdown() {
                 href="/docs/mentoring"
                 className="block px-4 py-2 text-gray-600 hover:text-gray-900"
               >
-                mentoring
+                Mentoring
               </Link>
               <Link
                 href="/docs/mentoring/choosing"

--- a/app/docs/mentoring/mentoring-faq/page.jsx
+++ b/app/docs/mentoring/mentoring-faq/page.jsx
@@ -59,7 +59,7 @@ export default function MentoringFAQ() {
                 href="/docs/mentoring"
                 className="block px-4 py-2 text-gray-600 hover:text-gray-900"
               >
-                mentoring
+                Mentoring
               </Link>
               <Link
                 href="/docs/mentoring/choosing"

--- a/app/docs/mentoring/mindset/page.jsx
+++ b/app/docs/mentoring/mindset/page.jsx
@@ -58,7 +58,7 @@ export default function Mindset() {
                 href="/docs/mentoring"
                 className="block px-4 py-2 text-gray-600 hover:text-gray-900"
               >
-                mentoring
+                Mentoring
               </Link>
               <Link
                 href="/docs/mentoring/choosing"

--- a/app/docs/mentoring/representations/page.jsx
+++ b/app/docs/mentoring/representations/page.jsx
@@ -29,13 +29,13 @@ export default function Representations() {
             </Link>
             <Link
               href="/docs/mentoring"
-              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Mentoring
             </Link>
             <Link
               href="/docs/community"
-              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
             >
               Community
             </Link>
@@ -59,7 +59,7 @@ export default function Representations() {
                 href="/docs/mentoring"
                 className="block px-4 py-2 text-gray-600 hover:text-gray-900"
               >
-                mentoring
+                Mentoring
               </Link>
               <Link
                 href="/docs/mentoring/choosing"

--- a/app/docs/mentoring/tip/page.jsx
+++ b/app/docs/mentoring/tip/page.jsx
@@ -29,13 +29,15 @@ export default function Tips() {
             </Link>
             <Link
               href="/docs/mentoring"
-              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
+
             >
               Mentoring
             </Link>
             <Link
               href="/docs/community"
-              className=" text-[#2D1537] border-b-2 border-[#2D1537] hover:text-gray-900 h-full flex items-center flex-shrink-0"
+              className="text-gray-600 hover:text-gray-900 h-full flex items-center flex-shrink-0"
+
             >
               Community
             </Link>
@@ -59,7 +61,7 @@ export default function Tips() {
                 href="/docs/mentoring"
                 className="block px-4 py-2 text-gray-600 hover:text-gray-900"
               >
-                mentoring
+                Mentoring
               </Link>
               <Link
                 href="/docs/mentoring/choosing"


### PR DESCRIPTION
This pull request includes several changes to the `app/docs/mentoring` pages, primarily focusing on updating the class names for consistency and correcting the capitalization of the word "Mentoring" in various links.

Class name updates:

* [`app/docs/mentoring/choosing/page.jsx`](diffhunk://#diff-12ed650c400480606034302232ca3e71b2de9e35f44b79314c899250bba40015L32-R38): Updated the class names for the "Mentoring" and "Community" links to ensure consistent styling.
* [`app/docs/mentoring/feedback/page.jsx`](diffhunk://#diff-d4b9b288a129353a67a3f0adb8de23ff78ac93770d103ca77730a714bfeec05fL32-R38): Updated the class names for the "Mentoring" and "Community" links to ensure consistent styling.
* [`app/docs/mentoring/markdown/page.jsx`](diffhunk://#diff-96d05ce602b5f6b9e4bbe9a9e16c6e793a492ebadea78ed6db7c04c27b60d959L32-R38): Updated the class names for the "Mentoring" and "Community" links to ensure consistent styling.
* [`app/docs/mentoring/representations/page.jsx`](diffhunk://#diff-a1ed10cccb318fcd7af3ada24b6e10faf1a10a3f2f33d8f03d838e5f3fb2d218L32-R38): Updated the class names for the "Mentoring" and "Community" links to ensure consistent styling.
* [`app/docs/mentoring/tip/page.jsx`](diffhunk://#diff-80fac06d3c42b439d7d501d751c6dd7f17bf5396a8c2ce1182d6493b2c10dadaL32-R40): Updated the class names for the "Mentoring" and "Community" links to ensure consistent styling.

Capitalization corrections:

* [`app/docs/mentoring/choosing/page.jsx`](diffhunk://#diff-12ed650c400480606034302232ca3e71b2de9e35f44b79314c899250bba40015L62-R62): Corrected the capitalization of "mentoring" to "Mentoring" in the link text.
* [`app/docs/mentoring/markdown/page.jsx`](diffhunk://#diff-96d05ce602b5f6b9e4bbe9a9e16c6e793a492ebadea78ed6db7c04c27b60d959L62-R62): Corrected the capitalization of "mentoring" to "Mentoring" in the link text.
* [`app/docs/mentoring/mentoring-faq/page.jsx`](diffhunk://#diff-d719c47945e4accdff4055c6af09b0061ecf85eecc1e2fa4396f0644a5dcaa61L62-R62): Corrected the capitalization of "mentoring" to "Mentoring" in the link text.
* [`app/docs/mentoring/mindset/page.jsx`](diffhunk://#diff-3b90957f422ca1935ae495b134503e6cd942302115f333e13101a83a541b13a8L61-R61): Corrected the capitalization of "mentoring" to "Mentoring" in the link text.
* [`app/docs/mentoring/representations/page.jsx`](diffhunk://#diff-a1ed10cccb318fcd7af3ada24b6e10faf1a10a3f2f33d8f03d838e5f3fb2d218L62-R62): Corrected the capitalization of "mentoring" to "Mentoring" in the link text.
* [`app/docs/mentoring/tip/page.jsx`](diffhunk://#diff-80fac06d3c42b439d7d501d751c6dd7f17bf5396a8c2ce1182d6493b2c10dadaL62-R64): Corrected the capitalization of "mentoring" to "Mentoring" in the link text.… Community links across multiple pages