### PR TITLE
CORE: unify background and text colors across Software Engineering co…

### DIFF
--- a/app/programs/se/page.jsx
+++ b/app/programs/se/page.jsx
@@ -4,7 +4,7 @@ import MoreFQA from "@/components/FeaturesCards/MoreFAQ";
 export default function SoftwareEngineering() {
   return (
     <div>
-      <div className="min-h-screen bg-[#0A0A1B] text-white p-4 sm:p-6 md:p-8 flex flex-col items-center">
+      <div className="min-h-screen bg-white p-4 sm:p-6 md:p-8 flex flex-col items-center">
         <div className="w-full max-w-4xl">
           <div className="text-center mb-8 sm:mb-12">
             <img
@@ -14,10 +14,10 @@ export default function SoftwareEngineering() {
               width={80}
               height={80}
             />
-            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4">
+            <h1 className="text-3xl text-black  sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4">
               Software Engineering Essentials
             </h1>
-            <p className="text-gray-400 text-sm sm:text-base max-w-xl sm:max-w-2xl mx-auto px-4">
+            <p className="text-black text-sm sm:text-base max-w-xl sm:max-w-2xl mx-auto px-4">
               Learn the basics of programming, web development, and software
               engineering. Get started with the Software Engineering Program.
             </p>

--- a/app/programs/se/se-card.jsx
+++ b/app/programs/se/se-card.jsx
@@ -6,7 +6,7 @@ export default function SeCard() {
   return (
     <div className="min-h-screen  text-white p-4 sm:p-6 md:p-8 flex flex-col items-center">
       <div className="w-full max-w-4xl">
-        <Card className="bg-[#13132B] my-8 border-gray-700">
+        <Card className="bg-[#2D1537] my-8 border-[#2D1537]">
           <CardContent className="p-4 sm:p-6">
             <div className="flex flex-col sm:flex-row items-center">
               <img
@@ -21,11 +21,11 @@ export default function SeCard() {
                   <h2 className="text-xl sm:text-2xl text-white font-bold mb-2 sm:mb-0 sm:mr-3 text-center sm:text-left">
                     Frontend with JavaScript
                   </h2>
-                  <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                  <span className="bg-[#F3A833] text-black text-xs font-bold px-2 py-1 rounded">
                     NEW
                   </span>
                 </div>
-                <p className="text-[#2D1537] text-sm mb-3 text-center sm:text-left">
+                <p className="text-[#F3A833] text-sm mb-3 text-center sm:text-left">
                   06 Modules
                 </p>
                 <p className="text-sm text-gray-300 mb-4 text-center sm:text-left">
@@ -59,11 +59,11 @@ export default function SeCard() {
                   <h2 className="text-xl sm:text-2xl text-white font-bold mb-2 sm:mb-0 sm:mr-3 text-center sm:text-left">
                     Backend with Node.js
                   </h2>
-                  <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                  <span className="bg-[#F3A833] text-black text-xs font-bold px-2 py-1 rounded">
                     NEW
                   </span>
                 </div>
-                <p className="text-[#2D1537] text-sm mb-3 text-center sm:text-left">
+                <p className="text-[#F3A833] text-sm mb-3 text-center sm:text-left">
                   04 Modules
                 </p>
                 <p className="text-sm text-gray-300 mb-4 text-center sm:text-left">
@@ -97,11 +97,11 @@ export default function SeCard() {
                   <h2 className="text-xl sm:text-2xl text-white font-bold mb-2 sm:mb-0 sm:mr-3 text-center sm:text-left">
                     Database with MongoDB
                   </h2>
-                  <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                  <span className="bg-[#F3A833] text-black text-xs font-bold px-2 py-1 rounded">
                     NEW
                   </span>
                 </div>
-                <p className="text-[#2D1537] text-sm mb-3 text-center sm:text-left">
+                <p className="text-[#F3A833] text-sm mb-3 text-center sm:text-left">
                   02 Modules
                 </p>
                 <p className="text-sm text-gray-300 mb-4 text-center sm:text-left">
@@ -135,11 +135,11 @@ export default function SeCard() {
                   <h2 className="text-xl sm:text-2xl text-white font-bold mb-2 sm:mb-0 sm:mr-3 text-center sm:text-left">
                     DevOps for Beginners
                   </h2>
-                  <span className="bg-green-500 text-black text-xs font-bold px-2 py-1 rounded">
+                  <span className="bg-[#F3A833] text-black text-xs font-bold px-2 py-1 rounded">
                     NEW
                   </span>
                 </div>
-                <p className="text-[#2D1537] text-sm mb-3 text-center sm:text-left">
+                <p className="text-[#F3A833] text-sm mb-3 text-center sm:text-left">
                   04 Modules
                 </p>
                 <p className="text-sm text-gray-300 mb-4 text-center sm:text-left">


### PR DESCRIPTION
This pull request includes changes to the `SoftwareEngineering` and `SeCard` components to update the color scheme and improve the visual consistency of the application. The most important changes include updating background and text colors, as well as modifying the appearance of badges and module descriptions.

Changes to `SoftwareEngineering` component:

* Updated the background color of the main container from dark blue to white and changed text colors to black for better readability. (`app/programs/se/page.jsx`, [[1]](diffhunk://#diff-439bfed0743965322be29169b2109471d07103ff1ebad09d4287c339b3fc6d52L7-R7) [[2]](diffhunk://#diff-439bfed0743965322be29169b2109471d07103ff1ebad09d4287c339b3fc6d52L17-R20)

Changes to `SeCard` component:

* Changed the background color of the card and its border to a different shade of purple for a more cohesive look. (`app/programs/se/se-card.jsx`, [app/programs/se/se-card.jsxL9-R9](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L9-R9))
* Updated the badge color from green to a specific shade of orange to match the new design theme. (`app/programs/se/se-card.jsx`, [[1]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L24-R28) [[2]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L62-R66) [[3]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L100-R104) [[4]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L138-R142)
* Modified the module description text color to the same shade of orange used for the badges for consistency. (`app/programs/se/se-card.jsx`, [[1]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L24-R28) [[2]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L62-R66) [[3]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L100-R104) [[4]](diffhunk://#diff-f19beeb53a4ff5177f367cb1998b4bf77b65ead89036e21e1fff6a0e446213f4L138-R142)…mponents